### PR TITLE
fix: prevent undefined assistant message content in tool-only responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mymediset/sap-ai-provider",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mymediset/sap-ai-provider",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "^2.0.0",
@@ -38,7 +38,6 @@
       "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.0.tgz",
       "integrity": "sha512-VEm87DyRx1yIPywbTy8ntoyh4jEDv1rJ88m+2I7zOm08jJI5BhFtAWh0OF6YzZu1Vu4NxhOWO4ssGdsqydDQ3A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
         "@ai-sdk/provider-utils": "3.0.0"
@@ -116,6 +115,7 @@
       "integrity": "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@edge-runtime/primitives": "6.0.0"
       },
@@ -943,7 +943,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1447,6 +1446,7 @@
       "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1503,6 +1503,7 @@
       "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.39.0",
         "@typescript-eslint/types": "8.39.0",
@@ -1783,6 +1784,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2417,6 +2419,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2470,6 +2473,7 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3975,6 +3979,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4024,6 +4029,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -4824,6 +4830,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -154,38 +154,4 @@ describe("convertToSAPMessages", () => {
     expect(result[2].role).toBe("assistant");
     expect(result[3].role).toBe("user");
   });
-
-  it("should convert assistant message with ONLY tool calls (no text) to empty string content", () => {
-    const prompt: LanguageModelV2Prompt = [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool-call",
-            toolCallId: "call_abc",
-            toolName: "search_docs",
-            input: { query: "SAP AI Core" },
-          },
-        ],
-      },
-    ];
-
-    const result = convertToSAPMessages(prompt);
-
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
-      role: "assistant",
-      content: "",  // Should be empty string, NOT undefined
-      tool_calls: [
-        {
-          id: "call_abc",
-          type: "function",
-          function: {
-            name: "search_docs",
-            arguments: '{"query":"SAP AI Core"}',
-          },
-        },
-      ],
-    });
-  });
 });

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -99,7 +99,7 @@ describe("convertToSAPMessages", () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
       role: "assistant",
-      content: undefined,
+      content: "",
       tool_calls: [
         {
           id: "call_123",
@@ -153,5 +153,39 @@ describe("convertToSAPMessages", () => {
     expect(result[1].role).toBe("user");
     expect(result[2].role).toBe("assistant");
     expect(result[3].role).toBe("user");
+  });
+
+  it("should convert assistant message with ONLY tool calls (no text) to empty string content", () => {
+    const prompt: LanguageModelV2Prompt = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call_abc",
+            toolName: "search_docs",
+            input: { query: "SAP AI Core" },
+          },
+        ],
+      },
+    ];
+
+    const result = convertToSAPMessages(prompt);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      role: "assistant",
+      content: "",  // Should be empty string, NOT undefined
+      tool_calls: [
+        {
+          id: "call_abc",
+          type: "function",
+          function: {
+            name: "search_docs",
+            arguments: '{"query":"SAP AI Core"}',
+          },
+        },
+      ],
+    });
   });
 });

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -179,7 +179,7 @@ export function convertToSAPMessages(
 
         const assistantMessage: AssistantChatMessage = {
           role: "assistant",
-          content: text || undefined,
+          content: text || "",
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         };
         messages.push(assistantMessage);


### PR DESCRIPTION
## Problem

When an assistant message contains only tool_calls without text content, the provider generates `content: undefined` which causes SAP AI Core to reject requests with:
```
400 - LLM Module: Assistant Message content field is not provided
```

## Root Cause

In `src/convert-to-sap-messages.ts` line 182:
```typescript
content: text || undefined,  // ❌ generates void 0
```

Introduced by PR https://github.com/BITASIA/sap-ai-provider/pull/20 authored by @codeyogi911 

## Solution

Replace `void 0` with empty string:
```typescript
content: text || "",  // ✅ generates empty string
```

## Impact

- Fixes tool calling scenarios where assistant responds with only function calls
- Maintains backward compatibility (empty string is valid per OpenAI spec)
- Resolves SSE stream errors in multi-turn conversations

## Testing

Tested with SAP AI Core deployment using tool-enabled models. Confirmed:
- ✅ Tool-only responses no longer cause 400 errors
- ✅ Mixed text+tool responses work correctly
- ✅ Text-only responses unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure assistant messages without text use empty string content instead of undefined, updating tests accordingly.
> 
> - **Conversion Logic**:
>   - In `src/convert-to-sap-messages.ts`, set assistant `content` to `""` when no text is present while preserving `tool_calls`.
> - **Tests**:
>   - Update `src/convert-to-sap-messages.test.ts` to expect empty string `content` for tool-only assistant messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af0062bb9c6d46ad9477668e8494340bf0268c5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->