### PR TITLE
chore: validate package-lock.json sync in release workflow

### DIFF
--- a/.github/workflows/npm-publish-npm-packages.yml
+++ b/.github/workflows/npm-publish-npm-packages.yml
@@ -15,10 +15,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Validate lockfile
-        run: |
-          npm install --package-lock-only
-          git diff --exit-code package-lock.json || (echo "package-lock.json is out of sync. Run 'npm install' and commit the changes." && exit 1)
+      - name: Validate lockfile synchronization
+        run: npm ci --dry-run --ignore-scripts
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/.github/workflows/npm-publish-npm-packages.yml
+++ b/.github/workflows/npm-publish-npm-packages.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Validate lockfile
+        run: |
+          npm install --package-lock-only
+          git diff --exit-code package-lock.json || (echo "package-lock.json is out of sync. Run 'npm install' and commit the changes." && exit 1)
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
Adds lockfile synchronization validation to the npm publish workflow to ensure reproducible installs.

Validates that `package-lock.json` is synchronized with `package.json` before building and publishing the package. This prevents releases with mismatched dependencies that could lead to non-reproducible installations.

**Changes:**
- Added validation step in `build` job before `npm ci`
- Executes `npm install --package-lock-only` and checks for lockfile modifications
- Fails fast with clear error message if lockfile is out of sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `npm ci --dry-run --ignore-scripts` lockfile sync check to the `build` job before install in the npm publish workflow.
> 
> - **CI / GitHub Actions** (`.github/workflows/npm-publish-npm-packages.yml`):
>   - **Build job**: Add "Validate lockfile synchronization" step running `npm ci --dry-run --ignore-scripts` before `npm ci` to ensure `package-lock.json` matches `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffb11548f1ee017f49f32afef53b452b16f59d0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->